### PR TITLE
CPB-1: Force restart required until we can properly install without r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.1.2
+- Bugfixes, seeing issues without restart so requiring restart for now
+
 ### 2.1.1
 - 2024.1-EAP Compatibility 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.drewzillawood.CustomProgressBar"
-version = "2.1.1"
+version = "2.1.2"
 
 repositories {
     mavenCentral()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,5 +1,5 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
-<idea-plugin>
+<idea-plugin require-restart="true">
     <!-- Unique identifier of the plugin. It should be FQN. It cannot be changed between the plugin versions. -->
     <id>com.drewzillawood.CustomProgressBar</id>
 
@@ -21,6 +21,11 @@
 
     <change-notes>
         <![CDATA[
+            <p>2.1.2</p>
+            <ul>
+                <li>Bugfixes, seeing issues without restart so requiring restart for now</li>
+            </ul>
+
             <p>2.1.1</p>
             <ul>
                 <li>2024.1-EAP Compatibility</li>
@@ -86,7 +91,7 @@
         <applicationConfigurable parentId="appearance"
                                  instance="com.drewzillawood.customprogressbar.settings.CustomProgressBarConfigurable"
                                  id="org.intellij.sdk.settings.AppSettingsConfigurable"
-                                 dynamic="true"
+                                 dynamic="false"
                                  displayName="Custom Progress Bar"/>
         <applicationService serviceImplementation="com.drewzillawood.customprogressbar.settings.CustomProgressBarSettings"/>
         <postStartupActivity implementation="com.drewzillawood.customprogressbar.notification.activities.PluginUpdatedActivity"/>


### PR DESCRIPTION
## What Changed:
* Bug fixes, requiring restart for now until lack of restart incurs zero exceptions
  * Resolves #1 
  * Resolves #2 

## Why it Changed:
* Multiple bugs reported if attempting download without restart

## Testing:
* Download newest version and see if exceptions persist